### PR TITLE
Ajout de Graphviz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get install -y --no-install-recommends \
         python3-lxml
 
 RUN apt-get install -y --no-install-recommends \
-        plantuml
+        plantuml \
+        graphviz
 
 RUN apt-get install -y --no-install-recommends \
         git \


### PR DESCRIPTION
_(Pour les besoins du poly de NF26)_

Ajout de `graphviz` dans les paquets à installer aux côtés de `plantuml`.
`graphviz` n'est que dans les `Recommended packages` lors de l'installation de `plantuml` alors que `plantuml` en a quasiment systématiquement besoin.